### PR TITLE
chore: assign new issues to project board

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: Add Issue to project
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  track_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{secrets.BOOST_BOARD}}
+          ORGANIZATION: filecoin-project
+          PROJECT_NUMBER: 29
+        run: |
+          gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+      - name: Add Issue to project
+        env:
+          GITHUB_TOKEN: ${{secrets.BOOST_BOARD}}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          item_id="$( gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"


### PR DESCRIPTION
This adds a new workflow that will assign any added issues to the Boost project - https://github.com/orgs/filecoin-project/projects/29. This is a sibling to https://github.com/filecoin-project/boost/pull/423

I've added a BOOST_BOARD secret to the boost and boost-docs repo with minimal permissions to perform the action of assigning issues to the project via the graphql endpoint. This token is set to a 90 day expiration and will need to be rotated by then.