### PR TITLE
Improve http docs

### DIFF
--- a/experimental-features/http-retrieval.md
+++ b/experimental-features/http-retrieval.md
@@ -2,7 +2,9 @@
 
 Boost is introducing a new binary, `booster-http`, with release v1.2.0-rc2. This binary can be run alongside the `boostd` market process in order to serve retrievals over http.&#x20;
 
-Currently, there is no payment method or security integrated in the new binary. It can be run with any stable release of `boostd` and can also be run on a separate machine from the `boostd` process.
+Currently, there is no payment method or built-in security integrated in the new binary. It can be run with any stable release of `boostd` and can also be run on a separate machine from the `boostd` process.
+
+### Trying It Out
 
 To build and run `booster-http` :\
 \
@@ -50,3 +52,37 @@ curl http://localhost:7777/payload/<payload cid> > /tmp/download.piece
 # Download CAR by payload CID
 curl http://localhost:7777/payload/<payload cid>.car > /tmp/download.car
 ```
+
+## Running Public Boost HTTP Retrieval
+
+The Boost HTTP instance runs by default simply listening on localhost. If you want to make retrievals public, you'll want to run a reverse proxy such as NGINX to handle operational concerns like:
+- SSL
+- Authentication if you want it
+- Load balancing if you want to run multiple instances of booster-http
+
+While booster-http may get more operational features over time, the intent is that providers who want to scale their HTTP operations will handle most of operational concerns via software in front of booster-http rather than booster-http itself
+
+### Making HTTP Retrieval Discoverable
+
+If you are running Boost HTTP Retrieval publicly, you will want to set your domain root by editing Boost's `config.toml` and under the `[DealMaking]` section, set `HTTPRetrievalURL` to the public domain root you will serve HTTP retrievals.
+
+Example `config.toml` section:
+
+```
+[DealMaking]
+  HTTPRetrievalURL = "https://www.awesomestorageprovider.com"
+```
+
+If HTTPRetrievalURL is set, anyone running boost client can determine if you offer a given piece over HTTP by running:
+
+```
+boost retrieve-piece --provider <your provider address> --piece-cid <piece-cid>
+```
+
+If you have the piece and have set HTTPRetrievalURL, they will receive a URL like:
+
+```
+https://www.awesomestorageprovider.com/piece/<piece cid>
+```
+
+Which they can then `curl` to get the piece from you.


### PR DESCRIPTION
# Goals

Add information on running HTTP retrieval in public and config settings for making HTTP retrieval discoverable.

# Implementation

Add two sections:
- Advice on running booster-http behind nginx for scalability, security, and authentication
- How to set your URL in the config so your provider's HTTP is discoverable with `boost retrieve-piece`

# For Discussion

Depends on https://github.com/filecoin-project/boost/pull/671, https://github.com/filecoin-project/boost/pull/691, & https://github.com/filecoin-project/boost/pull/698 getting merged and released