### PR TITLE
fix: do not use deprecated ProjectNext API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,29 +16,22 @@ jobs:
           gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
             query($org: String!, $number: Int!) {
               organization(login: $org){
-                projectNext(number: $number) {
+                projectV2(number: $number) {
                   id
-                  fields(first:20) {
-                    nodes {
-                      id
-                      name
-                      settings
-                    }
-                  }
                 }
               }
             }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
-          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
       - name: Add Issue to project
         env:
           GITHUB_TOKEN: ${{secrets.BOOST_BOARD}}
           ISSUE_ID: ${{ github.event.issue.node_id }}
         run: |
-          item_id="$( gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+          item_id="$(gh api graphql -f query='
             mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectV2ItemById.item.id')"


### PR DESCRIPTION
ProjectNext API is now deprecated and has been replaced with ProjectV2 API (https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/).

If you're interested in continuously adding issues matching certain queries to your project, we (IPDX) have a piece of automation running on schedule for that. We have it running for IPFS GUI project for example - https://github.com/galargh/.github/blob/master/.github/workflows/add-issues-to-gui-project.yml Ping me if you were interested. 