### PR TITLE
docs: update compatibility matrix

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -12,14 +12,10 @@ The Boost source code repository is hosted at [github.com/filecoin-project/boost
 
 | Boost Version | Lotus Version                          |
 | ------------- | -------------------------------------- |
-| v1.0.0        | v1.15.x                                |
-| v1.1.0        | v1.16.x                                |
-| v1.1.1        | v1.16.x                                |
-| v1.2.0        | v1.16.x                                |
-| v1.3.0        | v1.17.0, v1.17.1                       |
 | v1.4.0        | v1.17.0, v1.17.1, v1.17.2, v1.18.0-rc1 |
 | v1.5.0        | v1.18.0                                |
 | v1.5.1-rc2    | v1.18.0, v1.19.0                       |
+| v1.6.0-rc1    | v1.20.0-rc1.                           |
 
 ### Building and installing
 


### PR DESCRIPTION
* Remove older versions from the list as users should be on at least Lotus 1.18.x
* Adds the upcoming lotus compat update to the list