### PR TITLE
docs: update compat for Boost 1.5.1

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -14,7 +14,7 @@ The Boost source code repository is hosted at [github.com/filecoin-project/boost
 | ------------- | -------------------------------------- |
 | v1.4.0        | v1.17.0, v1.17.1, v1.17.2, v1.18.0-rc1 |
 | v1.5.0        | v1.18.0                                |
-| v1.5.1-rc2    | v1.18.0, v1.19.0                       |
+| v1.5.1        | v1.18.0, v1.19.0                       |
 | v1.6.0-rc1    | v1.20.0-rc1                            |
 
 ### Building and installing


### PR DESCRIPTION
Updates the support matrix with Boost 1.5.1 in replace of its previous RC.